### PR TITLE
Enable F8E4M3 conversions on Nvidia GPUs with sm < 89, and fix F8E5M2 conversions

### DIFF
--- a/python/test/regression/test_cast_matmul.py
+++ b/python/test/regression/test_cast_matmul.py
@@ -15,10 +15,7 @@ from triton._internal_testing import is_hip_cdna3, is_cuda, is_hip
 
 input_dtypes = ["bfloat16", "float16", "float32"]
 if is_cuda():
-    input_dtypes += ["int8", "float8_e5m2"]
-    cc = torch.cuda.get_device_capability(0)
-    if cc >= (8, 9):
-        input_dtypes += ["float8_e4m3fn"]
+    input_dtypes += ["int8", "float8_e5m2", "float8_e4m3fn"]
 elif is_hip_cdna3():
     input_dtypes += [
         "int8",

--- a/python/test/unit/language/test_compile_errors.py
+++ b/python/test/unit/language/test_compile_errors.py
@@ -355,14 +355,12 @@ def test_where_warning(fresh_triton_cache):
 @pytest.mark.parametrize("dtype", [tl.float8e5, tl.float8e5b16, tl.float8e4nv, tl.float8e4b8, tl.float8e4b15])
 def test_fp8_support(fresh_triton_cache, dtype):
     warning_dtypes = []
-    supported_dtypes = [tl.float8e5]
+    supported_dtypes = [tl.float8e5, tl.float8e4nv]
     if is_cuda():
         cc = torch.cuda.get_device_capability(0)
         supported_dtypes.append(tl.float8e4b15)
         if cc >= (9, 0):
             warning_dtypes.append(tl.float8e4b15)
-        if cc >= (8, 9):
-            supported_dtypes.append(tl.float8e4nv)
     elif is_hip():
         if is_hip_cdna3():
             supported_dtypes += [tl.float8e4nv, tl.float8e4b8, tl.float8e5b16]

--- a/python/test/unit/language/test_conversions.py
+++ b/python/test/unit/language/test_conversions.py
@@ -275,8 +275,7 @@ def test_typeconvert_upcast(src_dtype, dst_dtype, device):
     # On HIP, fp8e4nv upcasting to fp32 is only supported on CDNA4, and
     # fp8e4nv upcasting to bf16 and fp16 is only supported on CDNA3 and CDNA4.
     if is_cuda():
-        if ((src_dtype == 'float8e4nv' and torch.cuda.get_device_capability(0) < (8, 9))
-            or src_dtype in ('float8e4b8', 'float8e5b16')):
+        if src_dtype in ('float8e4b8', 'float8e5b16'):
             # If the dtype should error out in the given device, we assert that and return
             with pytest.raises(triton.CompilationError, match="not supported in this architecture"):
                 launch_exhaustive_populate(getattr(tl, src_dtype), 0, 65536, False, 8, 0x7f, device=device)

--- a/python/test/unit/language/test_conversions.py
+++ b/python/test/unit/language/test_conversions.py
@@ -330,12 +330,6 @@ def test_typeconvert_upcast(src_dtype, dst_dtype, device):
 def test_typeconvert_downcast(src_dtype, dst_dtype, rounding, max_repr, device):
 
     if is_cuda():
-        if src_dtype != 'float32' and torch.cuda.get_device_capability(0) < (9, 0):
-            pytest.skip("non-float32 downcast tests only supported on NVGPU with compute capability 9.0+")
-
-        if dst_dtype in ('float8e5', 'float8e4nv') and rounding == 'rtne' and torch.cuda.get_device_capability(0) < (9, 0):
-            pytest.skip(f"{dst_dtype} downcast with RTNE rounding tests only supported on NVGPU with compute capability 9.0+")
-
         if dst_dtype in ('float8e5b16', 'float8e4b8') and rounding == 'rtne':
             pytest.skip(f"{dst_dtype} downcast with RTNE rounding tests only supported on AMDGPU CDNA3")
 

--- a/python/test/unit/language/test_core.py
+++ b/python/test/unit/language/test_core.py
@@ -1218,8 +1218,6 @@ def test_abs_fp8(in_dtype, device):
         cc = torch.cuda.get_device_capability()
         if in_dtype == tl.float8e4b15 and cc >= (9, 0):
             pytest.skip("float8e4b15 not supported on CUDA >= 9.0")
-        if in_dtype == tl.float8e4nv and cc < (8, 9):
-            pytest.skip("float8e4nv not supported on CUDA < 8.9")
 
     @triton.jit
     def abs_kernel(X, Z, SIZE: tl.constexpr):

--- a/third_party/nvidia/backend/compiler.py
+++ b/third_party/nvidia/backend/compiler.py
@@ -121,7 +121,7 @@ class CUDAOptions:
     enable_fp_fusion: bool = True
     launch_cooperative_grid: bool = False
     launch_pdl: bool = False
-    supported_fp8_dtypes: Tuple[str] = ("fp8e5", "fp8e4b15")
+    supported_fp8_dtypes: Tuple[str] = ("fp8e4nv", "fp8e5", "fp8e4b15")
     deprecated_fp8_dot_operand_dtypes: Tuple[str] = ()
     default_dot_input_precision: str = "tf32"
     allowed_dot_input_precisions: Tuple[str] = ("tf32", "tf32x3", "ieee")
@@ -177,8 +177,6 @@ class CUDABackend(BaseBackend):
 
         if "supported_fp8_dtypes" not in args:
             supported_fp8_dtypes = set(CUDAOptions.supported_fp8_dtypes)
-            if capability >= 89:
-                supported_fp8_dtypes.add("fp8e4nv")
             args["supported_fp8_dtypes"] = tuple(sorted(supported_fp8_dtypes))
 
         if "deprecated_fp8_dot_operand_dtypes" not in args:

--- a/third_party/nvidia/lib/TritonNVIDIAGPUToLLVM/ElementwiseOpToLLVM.cpp
+++ b/third_party/nvidia/lib/TritonNVIDIAGPUToLLVM/ElementwiseOpToLLVM.cpp
@@ -282,36 +282,34 @@ static const Fp8ConversionDesc Fp8E4M3Nv_to_Bf16(bool hasNativeFP8,
         "lop3.b32 $1, b1, 0x80008000, a1, 0xf8;   \n" // (restore sign)
         "}",
         32, 32, 4};
-  } else {
+  } else if (!hasNativeBF16F16) {
     // Fp8E4M3 (x2) -> Bf16 (x2) (packed)
-    if (!hasNativeBF16F16) {
-      ret = {"{                                       \n"
-             ".reg .b32 a;                            \n"
-             ".reg .f16 a<2>;                         \n"
-             ".reg .f32 b<2>;                         \n"
-             ".reg .b16 c<2>;                         \n"
-             "cvt.rn.f16x2.e4m3x2 a, $1;              \n"
-             "mov.b32 {a0, a1}, a;                    \n"
-             "cvt.f32.f16 b0, a0;                     \n"
-             "cvt.f32.f16 b1, a1;                     \n"
-             "cvt.rn.bf16.f32 c0, b0;                 \n"
-             "cvt.rn.bf16.f32 c1, b1;                 \n"
-             "mov.b32 $0, {c0, c1};                   \n"
-             "}",
-             16, 32, 2};
-    } else {
-      ret = {"{                                       \n"
-             ".reg .b32 a;                            \n"
-             ".reg .f16 a<2>;                         \n"
-             ".reg .b16 b<2>;                         \n"
-             "cvt.rn.f16x2.e4m3x2 a, $1;              \n"
-             "mov.b32 {a0, a1}, a;                    \n"
-             "cvt.bf16.f16 b0, a0;                    \n"
-             "cvt.bf16.f16 b1, a1;                    \n"
-             "mov.b32 $0, {b0, b1};                   \n"
-             "}",
-             16, 32, 2};
-    }
+    ret = {"{                                       \n"
+           ".reg .b32 a;                            \n"
+           ".reg .f16 a<2>;                         \n"
+           ".reg .f32 b<2>;                         \n"
+           ".reg .b16 c<2>;                         \n"
+           "cvt.rn.f16x2.e4m3x2 a, $1;              \n"
+           "mov.b32 {a0, a1}, a;                    \n"
+           "cvt.f32.f16 b0, a0;                     \n"
+           "cvt.f32.f16 b1, a1;                     \n"
+           "cvt.rn.bf16.f32 c0, b0;                 \n"
+           "cvt.rn.bf16.f32 c1, b1;                 \n"
+           "mov.b32 $0, {c0, c1};                   \n"
+           "}",
+           16, 32, 2};
+  } else {
+    ret = {"{                                       \n"
+           ".reg .b32 a;                            \n"
+           ".reg .f16 a<2>;                         \n"
+           ".reg .b16 b<2>;                         \n"
+           "cvt.rn.f16x2.e4m3x2 a, $1;              \n"
+           "mov.b32 {a0, a1}, a;                    \n"
+           "cvt.bf16.f16 b0, a0;                    \n"
+           "cvt.bf16.f16 b1, a1;                    \n"
+           "mov.b32 $0, {b0, b1};                   \n"
+           "}",
+           16, 32, 2};
   }
   return ret;
 }
@@ -564,6 +562,7 @@ struct FpToFpOpConversion
              Fp8E4M3Nv_to_Fp16(computeCapability >= 89)},
             {{F8E5M2TyID, F16TyID, undefRounding},
              Fp8E5M2_to_Fp16(computeCapability >= 89)},
+            // F16 -> F8
             {{F16TyID, F8E4M3TyID, RoundingMode::RTNE},
              Fp16_to_Fp8E4M3Nv(computeCapability >= 89)},
             {{F16TyID, F8E5M2TyID, RoundingMode::RTNE},

--- a/third_party/nvidia/lib/TritonNVIDIAGPUToLLVM/ElementwiseOpToLLVM.cpp
+++ b/third_party/nvidia/lib/TritonNVIDIAGPUToLLVM/ElementwiseOpToLLVM.cpp
@@ -77,8 +77,8 @@ static const Fp8ConversionDesc Fp8E5M2_to_Bf16(bool hasNativeFP) {
         "prmt.b32 a1, 0, $2, 0x7362;              \n" // a1 = 0xf100f200
         "and.b32 b0, a0, 0x7fff7fff;              \n" // strip sign
         "and.b32 b1, a1, 0x7fff7fff;              \n"
-        "shr.b32 b0, b0, 3;                       \n" // b0 >>= 3
-        "shr.b32 b1, b1, 3;                       \n" // shift to bf16 position
+        "shr.b32 b0, b0, 3;                       \n" // shift to bf16 position
+        "shr.b32 b1, b1, 3;                       \n"
         "and.b32 c0, b0, 0xffff0000;              \n" // c0 = f3
         "shl.b32 c1, b0, 16;                      \n" // c1 = f4
         "and.b32 c2, b1, 0xffff0000;              \n" // c2 = f1
@@ -203,8 +203,8 @@ static const Fp8ConversionDesc Fp8E4M3Nv_to_Fp16(bool hasNativeFP) {
         "prmt.b32 a1, 0, $2, 0x7362;              \n" // a1 = 0xf100f200
         "and.b32 b0, a0, 0x7fff7fff;              \n" // strip sign
         "and.b32 b1, a1, 0x7fff7fff;              \n"
-        "shr.b32 b0, b0, 4;                       \n" // b0 >>= 4
-        "shr.b32 b1, b1, 4;                       \n" // shift to bf16 position
+        "shr.b32 b0, b0, 4;                       \n" // shift to bf16 position
+        "shr.b32 b1, b1, 4;                       \n"
         "and.b32 c0, b0, 0xffff0000;              \n" // c0 = f3
         "shl.b32 c1, b0, 16;                      \n" // c1 = f4
         "and.b32 c2, b1, 0xffff0000;              \n" // c2 = f1
@@ -215,8 +215,8 @@ static const Fp8ConversionDesc Fp8E4M3Nv_to_Fp16(bool hasNativeFP) {
         "mul.f32 c3, c3, e8;                      \n"
         "prmt.b32 b0, c0, c1, 0x3276;             \n" // b0 = 0xc0c1
         "prmt.b32 b1, c2, c3, 0x3276;             \n" // b1 = 0xc2c3
-        "shl.b32 b0, b0, 3;                       \n" // b0 <<= 3
-        "shl.b32 b1, b1, 3;                       \n" // shift to fp16 position
+        "shl.b32 b0, b0, 3;                       \n" // shift to fp16 position
+        "shl.b32 b1, b1, 3;                       \n"
         "lop3.b32 $0, b0, 0x80008000, a0, 0xf8;   \n" // out0=b0|(0x80008000&a0)
         "lop3.b32 $1, b1, 0x80008000, a1, 0xf8;   \n" // (restore sign)
         "}",
@@ -313,8 +313,8 @@ static const Fp8ConversionDesc Fp8E4M3Nv_to_Bf16(bool hasNativeFP8,
         "prmt.b32 a1, 0, $2, 0x7362;              \n" // a1 = 0xf100f200
         "and.b32 b0, a0, 0x7fff7fff;              \n" // strip sign
         "and.b32 b1, a1, 0x7fff7fff;              \n"
-        "shr.b32 b0, b0, 4;                       \n" // b0 >>= 4
-        "shr.b32 b1, b1, 4;                       \n" // shift to bf16 position
+        "shr.b32 b0, b0, 4;                       \n" // shift to bf16 position
+        "shr.b32 b1, b1, 4;                       \n"
         "and.b32 c0, b0, 0xffff0000;              \n" // c0 = f3
         "shl.b32 c1, b0, 16;                      \n" // c1 = f4
         "and.b32 c2, b1, 0xffff0000;              \n" // c2 = f1

--- a/third_party/nvidia/lib/TritonNVIDIAGPUToLLVM/ElementwiseOpToLLVM.cpp
+++ b/third_party/nvidia/lib/TritonNVIDIAGPUToLLVM/ElementwiseOpToLLVM.cpp
@@ -148,14 +148,14 @@ static const Fp8ConversionDesc Bf16_to_Fp8E5M2(bool hasNativeFP) {
         "and.b32 lsb1, c1, 0x00200000;               \n" // then add 0x00100000
         "and.b32 lsb2, c2, 0x00200000;               \n" // else add 0x000fffff
         "and.b32 lsb3, c3, 0x00200000;               \n"
-        "add.u32 c0, c0, 0x000fffff;                 \n"
-        "add.u32 c1, c1, 0x000fffff;                 \n"
-        "add.u32 c2, c2, 0x000fffff;                 \n"
-        "add.u32 c3, c3, 0x000fffff;                 \n"
         "shr.b32 lsb0, lsb0, 21;                     \n"
         "shr.b32 lsb1, lsb1, 21;                     \n"
         "shr.b32 lsb2, lsb2, 21;                     \n"
         "shr.b32 lsb3, lsb3, 21;                     \n"
+        "add.u32 c0, c0, 0x000fffff;                 \n"
+        "add.u32 c1, c1, 0x000fffff;                 \n"
+        "add.u32 c2, c2, 0x000fffff;                 \n"
+        "add.u32 c3, c3, 0x000fffff;                 \n"
         "add.u32 c0, c0, lsb0;                       \n"
         "add.u32 c1, c1, lsb1;                       \n"
         "add.u32 c2, c2, lsb2;                       \n"
@@ -266,14 +266,14 @@ static const Fp8ConversionDesc Fp16_to_Fp8E4M3Nv(bool hasNativeFP) {
         "and.b32 lsb1, c1, 0x00100000;               \n" // then add 0x00080000
         "and.b32 lsb2, c2, 0x00100000;               \n" // else add 0x0007ffff
         "and.b32 lsb3, c3, 0x00100000;               \n"
-        "add.u32 c0, c0, 0x0007ffff;                 \n"
-        "add.u32 c1, c1, 0x0007ffff;                 \n"
-        "add.u32 c2, c2, 0x0007ffff;                 \n"
-        "add.u32 c3, c3, 0x0007ffff;                 \n"
         "shr.b32 lsb0, lsb0, 20;                     \n"
         "shr.b32 lsb1, lsb1, 20;                     \n"
         "shr.b32 lsb2, lsb2, 20;                     \n"
         "shr.b32 lsb3, lsb3, 20;                     \n"
+        "add.u32 c0, c0, 0x0007ffff;                 \n"
+        "add.u32 c1, c1, 0x0007ffff;                 \n"
+        "add.u32 c2, c2, 0x0007ffff;                 \n"
+        "add.u32 c3, c3, 0x0007ffff;                 \n"
         "add.u32 c0, c0, lsb0;                       \n"
         "add.u32 c1, c1, lsb1;                       \n"
         "add.u32 c2, c2, lsb2;                       \n"
@@ -394,14 +394,14 @@ static const Fp8ConversionDesc Bf16_to_Fp8E4M3Nv(bool hasNativeFP) {
         "and.b32 lsb1, c1, 0x00100000;               \n" // then add 0x00080000
         "and.b32 lsb2, c2, 0x00100000;               \n" // else add 0x0007ffff
         "and.b32 lsb3, c3, 0x00100000;               \n"
-        "add.u32 c0, c0, 0x0007ffff;                 \n"
-        "add.u32 c1, c1, 0x0007ffff;                 \n"
-        "add.u32 c2, c2, 0x0007ffff;                 \n"
-        "add.u32 c3, c3, 0x0007ffff;                 \n"
         "shr.b32 lsb0, lsb0, 20;                     \n"
         "shr.b32 lsb1, lsb1, 20;                     \n"
         "shr.b32 lsb2, lsb2, 20;                     \n"
         "shr.b32 lsb3, lsb3, 20;                     \n"
+        "add.u32 c0, c0, 0x0007ffff;                 \n"
+        "add.u32 c1, c1, 0x0007ffff;                 \n"
+        "add.u32 c2, c2, 0x0007ffff;                 \n"
+        "add.u32 c3, c3, 0x0007ffff;                 \n"
         "add.u32 c0, c0, lsb0;                       \n"
         "add.u32 c1, c1, lsb1;                       \n"
         "add.u32 c2, c2, lsb2;                       \n"
@@ -462,36 +462,29 @@ static const Fp8ConversionDesc Fp32_to_Fp8E4M3Nv(bool hasNativeFP) {
         "sub.u32 d1, d1, e141;                       \n"
         "sub.u32 d2, d2, e141;                       \n"
         "sub.u32 d3, d3, e141;                       \n"
-        "shl.b32 d0, d0, 24;                         \n"
-        "shl.b32 d1, d1, 24;                         \n"
+        "shl.b32 d0, d0, 24;                         \n" // shift to highest
+        "shl.b32 d1, d1, 24;                         \n" // 8 bits
         "shl.b32 d2, d2, 24;                         \n"
         "shl.b32 d3, d3, 24;                         \n"
 
-        ".reg .b32 e120;                             \n"
-        "mov.b32 e120, 0x03800000;                   \n"
-        "mul.f32 c0, c0, e120;                       \n" // not fp8 denormal
-        "mul.f32 c1, c1, e120;                       \n" // move exponent bias
-        "mul.f32 c2, c2, e120;                       \n" // from 127 to 7
-        "mul.f32 c3, c3, e120;                       \n" // and handle denormal
-
-        "min.u32 c0, c0, 0x07f7ffff;                 \n" // avoid overflow
-        "min.u32 c1, c1, 0x07f7ffff;                 \n" // when RTNE
-        "min.u32 c2, c2, 0x07f7ffff;                 \n"
-        "min.u32 c3, c3, 0x07f7ffff;                 \n"
+        "min.u32 c0, c0, 0x43f7ffff;                 \n" // not fp8 denormal
+        "min.u32 c1, c1, 0x43f7ffff;                 \n" // avoid overflow
+        "min.u32 c2, c2, 0x43f7ffff;                 \n" // when RTNE
+        "min.u32 c3, c3, 0x43f7ffff;                 \n"
 
         ".reg .b32 lsb<4>;                           \n" // RTNE:
         "and.b32 lsb0, c0, 0x00100000;               \n" // if LSB is 1
         "and.b32 lsb1, c1, 0x00100000;               \n" // then add 0x00080000
         "and.b32 lsb2, c2, 0x00100000;               \n" // else add 0x0007ffff
         "and.b32 lsb3, c3, 0x00100000;               \n"
-        "add.u32 c0, c0, 0x0007ffff;                 \n"
-        "add.u32 c1, c1, 0x0007ffff;                 \n"
-        "add.u32 c2, c2, 0x0007ffff;                 \n"
-        "add.u32 c3, c3, 0x0007ffff;                 \n"
         "shr.b32 lsb0, lsb0, 20;                     \n"
         "shr.b32 lsb1, lsb1, 20;                     \n"
         "shr.b32 lsb2, lsb2, 20;                     \n"
         "shr.b32 lsb3, lsb3, 20;                     \n"
+        "add.u32 c0, c0, 0xc407ffff;                 \n" // move exponent bias
+        "add.u32 c1, c1, 0xc407ffff;                 \n" // from 127 to 7
+        "add.u32 c2, c2, 0xc407ffff;                 \n"
+        "add.u32 c3, c3, 0xc407ffff;                 \n"
         "add.u32 c0, c0, lsb0;                       \n"
         "add.u32 c1, c1, lsb1;                       \n"
         "add.u32 c2, c2, lsb1;                       \n"
@@ -511,7 +504,6 @@ static const Fp8ConversionDesc Fp32_to_Fp8E4M3Nv(bool hasNativeFP) {
         "lop3.b32 c1, c1, 0x80008000, $2, 0xf8;      \n" // (restore sign)
         "lop3.b32 c2, c2, 0x80008000, $3, 0xf8;      \n"
         "lop3.b32 c3, c3, 0x80008000, $4, 0xf8;      \n"
-
         "prmt.b32 c0, c0, c1, 0x7430;                \n" // c0 = 0xf300f400
         "prmt.b32 c2, c2, c3, 0x7430;                \n" // c2 = 0xf100f200
         "prmt.b32 $0, c0, c2, 0x7531;                \n" // output = 0xf1f2f3f4
@@ -552,14 +544,14 @@ static const Fp8ConversionDesc Fp32_to_Fp8E5M2(bool hasNativeFP) {
         "sub.u32 d1, d1, e134;                       \n"
         "sub.u32 d2, d2, e134;                       \n"
         "sub.u32 d3, d3, e134;                       \n"
-        "shl.b32 d0, d0, 24;                         \n"
-        "shl.b32 d1, d1, 24;                         \n"
+        "shl.b32 d0, d0, 24;                         \n" // shift to highest
+        "shl.b32 d1, d1, 24;                         \n" // 8 bits
         "shl.b32 d2, d2, 24;                         \n"
         "shl.b32 d3, d3, 24;                         \n"
 
-        "min.u32 c0, c0, 0x47efffff;                 \n" // avoid overflow
-        "min.u32 c1, c1, 0x47efffff;                 \n" // when RTNE
-        "min.u32 c2, c2, 0x47efffff;                 \n"
+        "min.u32 c0, c0, 0x47efffff;                 \n" // not fp8 denormal
+        "min.u32 c1, c1, 0x47efffff;                 \n" // avoid overflow
+        "min.u32 c2, c2, 0x47efffff;                 \n" // when RTNE
         "min.u32 c3, c3, 0x47efffff;                 \n"
 
         ".reg .b32 lsb<4>;                           \n" // RTNE:
@@ -594,7 +586,6 @@ static const Fp8ConversionDesc Fp32_to_Fp8E5M2(bool hasNativeFP) {
         "lop3.b32 c1, c1, 0x80008000, $2, 0xf8;      \n" // (restore sign)
         "lop3.b32 c2, c2, 0x80008000, $3, 0xf8;      \n"
         "lop3.b32 c3, c3, 0x80008000, $4, 0xf8;      \n"
-
         "prmt.b32 c0, c0, c1, 0x7430;                \n" // c0 = 0xf300f400
         "prmt.b32 c2, c2, c3, 0x7430;                \n" // c2 = 0xf100f200
         "prmt.b32 $0, c0, c2, 0x7531;                \n" // output = 0xf1f2f3f4

--- a/third_party/nvidia/lib/TritonNVIDIAGPUToLLVM/ElementwiseOpToLLVM.cpp
+++ b/third_party/nvidia/lib/TritonNVIDIAGPUToLLVM/ElementwiseOpToLLVM.cpp
@@ -68,6 +68,7 @@ static const Fp8ConversionDesc Fp8E5M2_to_Fp16(bool hasNativeFP) {
 static const Fp8ConversionDesc Fp8E5M2_to_Bf16(bool hasNativeFP) {
   Fp8ConversionDesc ret;
   if (!hasNativeFP) {
+    // TODO: Handle inf and NaN
     ret = {
         "{                                        \n"
         ".reg .b32 a<2>, b<2>, c<4>, d<4>, e112;  \n" // if input = 0xf1f2f3f4
@@ -77,20 +78,18 @@ static const Fp8ConversionDesc Fp8E5M2_to_Bf16(bool hasNativeFP) {
         "lop3.b32 b0, a0, 0x7fff7fff, 0, 0xc0;    \n" // b0 = a0 & 0x7fff7fff
         "lop3.b32 b1, a1, 0x7fff7fff, 0, 0xc0;    \n" // (strip sign)
         "shr.b32  b0, b0, 3;                      \n" // b0 >>= 3
-        "shr.b32  b1, b1, 3;                      \n" // shift into bf16
-                                                      // position
+        "shr.b32  b1, b1, 3;                      \n" // shift to bf16 position
         "and.b32 c0, b0, 0xffff0000;              \n" // c0 = f3
         "shl.b32 c1, b0, 16;                      \n" // c1 = f4
         "and.b32 c2, b1, 0xffff0000;              \n" // c2 = f1
         "shl.b32 c3, b1, 16;                      \n" // c3 = f2
-        "mul.f32 d0, c0, e112;                    \n" // d0 = c0 * 0x77800000
-        "mul.f32 d1, c1, e112;                    \n" // d1 = c1 * 0x77800000
-        "mul.f32 d2, c2, e112;                    \n" // d2 = c2 * 0x77800000
-        "mul.f32 d3, c3, e112;                    \n" // d3 = c3 * 0x77800000
+        "mul.f32 d0, c0, e112;                    \n" // move exponent bias
+        "mul.f32 d1, c1, e112;                    \n" // from 15 to 127
+        "mul.f32 d2, c2, e112;                    \n"
+        "mul.f32 d3, c3, e112;                    \n"
         "prmt.b32 b0, d0, d1, 0x3276;             \n" // b0 = 0xd3d4
         "prmt.b32 b1, d2, d3, 0x3276;             \n" // b1 = 0xd1d2
-        "lop3.b32 $0, b0, 0x80008000, a0, 0xf8;   \n" // out0 =
-                                                      // b0|(0x80008000&a0)
+        "lop3.b32 $0, b0, 0x80008000, a0, 0xf8;   \n" // out0=b0|(0x80008000&a0)
         "lop3.b32 $1, b1, 0x80008000, a1, 0xf8;   \n" // (restore sign)
         "}",
         32, 32, 4};
@@ -98,9 +97,8 @@ static const Fp8ConversionDesc Fp8E5M2_to_Bf16(bool hasNativeFP) {
     ret = {
         "{                                      \n"
         ".reg .b32 a<2>, b<2>;                  \n" // if input = 0xf1f2f3f4
-        ".reg .b32 e112;                        \n"
-        "mov.u32 e112, 0x77807780;              \n" // 2**112 represented as
-                                                    // bf16x2
+        ".reg .b32 e112;                        \n" // 2**112 represented as
+        "mov.u32 e112, 0x77807780;              \n" // bf16x2
         "prmt.b32 a0, 0, $2, 0x5140;            \n" // a0 = 0xf300f400
         "prmt.b32 a1, 0, $2, 0x7362;            \n" // a1 = 0xf100f200
         "lop3.b32 b0, a0, 0x7fff7fff, 0, 0xc0;  \n" // b0 = a0 & 0x7fff7fff
@@ -177,13 +175,12 @@ static const Fp8ConversionDesc Bf16_to_Fp8E5M2(bool hasNativeFP) {
 }
 
 /* ----- FP8E4M3 ------ */
-// Note: when handled by software, this format has
-// more than a single NaN values.
 
 static const Fp8ConversionDesc Fp8E4M3Nv_to_Fp16(bool hasNativeFP) {
   Fp8ConversionDesc ret;
   if (!hasNativeFP) {
     // Fp8E4M3 (x4) -> Fp16 (x4) (packed)
+    // TODO: Handle NaN
     ret = {
         "{                                        \n"
         ".reg .b32 a<2>, b<2>, c<4>, d<4>, e8;    \n" // if input = 0xf1f2f3f4
@@ -193,22 +190,19 @@ static const Fp8ConversionDesc Fp8E4M3Nv_to_Fp16(bool hasNativeFP) {
         "lop3.b32 b0, a0, 0x7fff7fff, 0, 0xc0;    \n" // b0 = a0 & 0x7fff7fff
         "lop3.b32 b1, a1, 0x7fff7fff, 0, 0xc0;    \n" // (strip sign)
         "shr.b32 b0, b0, 4;                       \n" // b0 >>= 4
-        "shr.b32 b1, b1, 4;                       \n" // shift into bf16
-                                                      // position
+        "shr.b32 b1, b1, 4;                       \n" // shift to bf16 position
         "and.b32 c0, b0, 0xffff0000;              \n" // c0 = f3
         "shl.b32 c1, b0, 16;                      \n" // c1 = f4
         "and.b32 c2, b1, 0xffff0000;              \n" // c2 = f1
         "shl.b32 c3, b1, 16;                      \n" // c3 = f2
-        // move exponent bias from 7 to 15
-        "mul.f32 d0, c0, e8;                      \n" // d0 = c0 * 0x43800000
-        "mul.f32 d1, c1, e8;                      \n" // d1 = c1 * 0x43800000
-        "mul.f32 d2, c2, e8;                      \n" // d2 = c2 * 0x43800000
-        "mul.f32 d3, c3, e8;                      \n" // d3 = c3 * 0x43800000
+        "mul.f32 d0, c0, e8;                      \n" // move exponent bias
+        "mul.f32 d1, c1, e8;                      \n" // from 7 to 15
+        "mul.f32 d2, c2, e8;                      \n"
+        "mul.f32 d3, c3, e8;                      \n"
         "prmt.b32 b0, d0, d1, 0x3276;             \n" // b0 = 0xd0d1
         "prmt.b32 b1, d2, d3, 0x3276;             \n" // b1 = 0xd2d3
         "shl.b32 b0, b0, 3;                       \n" // b0 <<= 3
-        "shl.b32 b1, b1, 3;                       \n" // shift into fp16
-                                                      // position
+        "shl.b32 b1, b1, 3;                       \n" // shift to fp16 position
         "lop3.b32 $0, b0, 0x80008000, a0, 0xf8;   \n" // out0=b0|(0x80008000&a0)
         "lop3.b32 $1, b1, 0x80008000, a1, 0xf8;   \n" // (restore sign)
         "}",
@@ -249,6 +243,7 @@ static const Fp8ConversionDesc Fp8E4M3Nv_to_Bf16(bool hasNativeFP8,
   Fp8ConversionDesc ret;
   if (!hasNativeFP8) {
     // Fp8E4M3 (x4) -> Bf16 (x4) (packed)
+    // TODO: Handle NaN
     ret = {
         "{                                        \n"
         ".reg .b32 a<2>, b<2>, c<4>, d<4>, e120;  \n" // if input = 0xf1f2f3f4
@@ -258,17 +253,15 @@ static const Fp8ConversionDesc Fp8E4M3Nv_to_Bf16(bool hasNativeFP8,
         "lop3.b32 b0, a0, 0x7fff7fff, 0, 0xc0;    \n" // b0 = a0 & 0x7fff7fff
         "lop3.b32 b1, a1, 0x7fff7fff, 0, 0xc0;    \n" // (strip sign)
         "shr.b32 b0, b0, 4;                       \n" // b0 >>= 4
-        "shr.b32 b1, b1, 4;                       \n" // shift into bf16
-                                                      // position
+        "shr.b32 b1, b1, 4;                       \n" // shift to bf16 position
         "and.b32 c0, b0, 0xffff0000;              \n" // c0 = f3
         "shl.b32 c1, b0, 16;                      \n" // c1 = f4
         "and.b32 c2, b1, 0xffff0000;              \n" // c2 = f1
         "shl.b32 c3, b1, 16;                      \n" // c3 = f2
-        // move exponent bias from 7 to 127
-        "mul.f32 d0, c0, e120;                    \n" // d0 = c0 * 0x7b800000
-        "mul.f32 d1, c1, e120;                    \n" // d1 = c1 * 0x7b800000
-        "mul.f32 d2, c2, e120;                    \n" // d2 = c2 * 0x7b800000
-        "mul.f32 d3, c3, e120;                    \n" // d3 = c3 * 0x7b800000
+        "mul.f32 d0, c0, e120;                    \n" // move exponent bias
+        "mul.f32 d1, c1, e120;                    \n" // from 7 to 127
+        "mul.f32 d2, c2, e120;                    \n"
+        "mul.f32 d3, c3, e120;                    \n"
         "prmt.b32 b0, d0, d1, 0x3276;             \n" // b0 = 0xd0d1
         "prmt.b32 b1, d2, d3, 0x3276;             \n" // b1 = 0xd2d3
         "lop3.b32 $0, b0, 0x80008000, a0, 0xf8;   \n" // out0=b0|(0x80008000&a0)

--- a/third_party/nvidia/lib/TritonNVIDIAGPUToLLVM/ElementwiseOpToLLVM.cpp
+++ b/third_party/nvidia/lib/TritonNVIDIAGPUToLLVM/ElementwiseOpToLLVM.cpp
@@ -187,8 +187,8 @@ static const Fp8ConversionDesc Fp8E4M3Nv_to_Fp16(bool hasNativeFP) {
     // Fp8E4M3 (x4) -> Fp16 (x4) (packed)
     ret = {
         "{                                        \n"
-        ".reg .b32 a<2>, b<2>, c<4>, d<4>, e112;  \n" // if input = 0xf1f2f3f4
-        "mov.u32 e112, 0x43800000;                \n"
+        ".reg .b32 a<2>, b<2>, c<4>, d<4>, e8;    \n" // if input = 0xf1f2f3f4
+        "mov.u32 e8, 0x43800000;                  \n"
         "prmt.b32 a0, 0, $2, 0x5140;              \n" // a0 = 0xf300f400
         "prmt.b32 a1, 0, $2, 0x7362;              \n" // a1 = 0xf100f200
         "lop3.b32 b0, a0, 0x7fff7fff, 0, 0xc0;    \n" // b0 = a0 & 0x7fff7fff
@@ -201,10 +201,10 @@ static const Fp8ConversionDesc Fp8E4M3Nv_to_Fp16(bool hasNativeFP) {
         "and.b32 c2, b1, 0xFFFF0000;              \n" // c2 = f1
         "shl.b32 c3, b1, 16;                      \n" // c3 = f2
         // move exponent bias from 7 to 15
-        "mul.f32 d0, c0, e112;                    \n" // d0 = c0 * 0x43800000
-        "mul.f32 d1, c1, e112;                    \n" // d1 = c1 * 0x43800000
-        "mul.f32 d2, c2, e112;                    \n" // d2 = c2 * 0x43800000
-        "mul.f32 d3, c3, e112;                    \n" // d3 = c3 * 0x43800000
+        "mul.f32 d0, c0, e8;                      \n" // d0 = c0 * 0x43800000
+        "mul.f32 d1, c1, e8;                      \n" // d1 = c1 * 0x43800000
+        "mul.f32 d2, c2, e8;                      \n" // d2 = c2 * 0x43800000
+        "mul.f32 d3, c3, e8;                      \n" // d3 = c3 * 0x43800000
         "prmt.b32 b0, d0, d1, 0x3276;             \n" // b0 = 0xd0d1
         "prmt.b32 b1, d2, d3, 0x3276;             \n" // b1 = 0xd2d3
         "shl.b32 b0, b0, 3;                       \n" // b0 <<= 3
@@ -258,8 +258,8 @@ static const Fp8ConversionDesc Fp8E4M3Nv_to_Bf16(bool hasNativeFP8,
     // Fp8E4M3 (x4) -> Bf16 (x4) (packed)
     ret = {
         "{                                        \n"
-        ".reg .b32 a<2>, b<2>, c<4>, d<4>, e112;  \n" // if input = 0xf1f2f3f4
-        "mov.u32 e112, 0x7b800000;                \n"
+        ".reg .b32 a<2>, b<2>, c<4>, d<4>, e120;  \n" // if input = 0xf1f2f3f4
+        "mov.u32 e120, 0x7b800000;                \n"
         "prmt.b32 a0, 0, $2, 0x5140;              \n" // a0 = 0xf300f400
         "prmt.b32 a1, 0, $2, 0x7362;              \n" // a1 = 0xf100f200
         "lop3.b32 b0, a0, 0x7fff7fff, 0, 0xc0;    \n" // b0 = a0 & 0x7fff7fff
@@ -272,10 +272,10 @@ static const Fp8ConversionDesc Fp8E4M3Nv_to_Bf16(bool hasNativeFP8,
         "and.b32 c2, b1, 0xFFFF0000;              \n" // c2 = f1
         "shl.b32 c3, b1, 16;                      \n" // c3 = f2
         // move exponent bias from 7 to 127
-        "mul.f32 d0, c0, e112;                    \n" // d0 = c0 * 0x7b800000
-        "mul.f32 d1, c1, e112;                    \n" // d1 = c1 * 0x7b800000
-        "mul.f32 d2, c2, e112;                    \n" // d2 = c2 * 0x7b800000
-        "mul.f32 d3, c3, e112;                    \n" // d3 = c3 * 0x7b800000
+        "mul.f32 d0, c0, e120;                    \n" // d0 = c0 * 0x7b800000
+        "mul.f32 d1, c1, e120;                    \n" // d1 = c1 * 0x7b800000
+        "mul.f32 d2, c2, e120;                    \n" // d2 = c2 * 0x7b800000
+        "mul.f32 d3, c3, e120;                    \n" // d3 = c3 * 0x7b800000
         "prmt.b32 b0, d0, d1, 0x3276;             \n" // b0 = 0xd0d1
         "prmt.b32 b1, d2, d3, 0x3276;             \n" // b1 = 0xd2d3
         "lop3.b32 $0, b0, 0x80008000, a0, 0xf8;   \n" // out0=b0|(0x80008000&a0)

--- a/third_party/nvidia/lib/TritonNVIDIAGPUToLLVM/ElementwiseOpToLLVM.cpp
+++ b/third_party/nvidia/lib/TritonNVIDIAGPUToLLVM/ElementwiseOpToLLVM.cpp
@@ -801,7 +801,8 @@ struct FpToFpOpConversion
             // F32 -> F8
             {{F32TyID, F8E4M3TyID, RoundingMode::RTNE},
              Fp32_to_Fp8E4M3Nv(computeCapability >= 90)},
-            {{F32TyID, F8E5M2TyID, RoundingMode::RTNE}, Fp32_to_Fp8E5M2},
+            {{F32TyID, F8E5M2TyID, RoundingMode::RTNE},
+             Fp32_to_Fp8E5M2(computeCapability >= 90)},
         };
     std::tuple<TypeID, TypeID, RoundingMode> key = {
         srcTy.getTypeID(), dstTy.getTypeID(),


### PR DESCRIPTION
## Motivation

Nvidia GPUs with sm < 89 are still widely used, see e.g. Steam hardware survey. When running large AI models, a common usage is to store the parameters in fp8, and cast them to fp16 for computation on hardware that doesn't have native fp8. This reduces the memory requirement, even though no speed advantage. This PR aims to enable `torch.compile` on this usage.

We may refer to XLA's fallback mechanism for fp8 operations, see https://github.com/openxla/xla/discussions/23124 , although I think we only need to support the conversions rather than all arithmetic operations.

## Implementation

Before https://github.com/triton-lang/triton/pull/2105 , there were some PTX code for converting F8E4M3/F8E5M2 <-> F16/BF16, but they did not correctly handle denormalized values and rounding to nearest even (RTNE). I've fixed these cases, and added the code for F32 -> F8E4M3/F8E5M2.

I've tested that for all 2^8 F8E4M3/F8E5M2 values, all 2^16 F16/BF16 values, and all 2^32 F32 values, the conversion results are bitwise identical to the [PyTorch implementation](https://github.com/pytorch/pytorch/blob/5e2ef2a465f79957faf5c56fe2a66d7a9b18e1a2/torch/headeronly/util/Float8_e4m3fn.h), except some glitches about inf and nan, see the comments. The tests in `test_conversions.py` are passed.

I've checked that all unit tests are passed on RTX 3080 (sm86). There is no IR change for sm >= 90. For sm89, there is a minor change that previously F32 -> F8E4M3/F8E5M2 was implemented by F32 -> F16 -> F8E4M3/F8E5M2 without correct RTNE, now it's directly implemented with RTNE.