### PR TITLE
[AMD/Windows] Fix clang-cl /std:c11 and use delete_on_close for NamedTemporaryFile (Python 3.12+ with fallback)

### DIFF
--- a/python/triton/runtime/build.py
+++ b/python/triton/runtime/build.py
@@ -65,12 +65,7 @@ def _cc_cmd(cc: str, src: str, out: str, include_dirs: list[str], library_dirs: 
             ccflags: list[str]) -> list[str]:
     if is_msvc(cc) or is_clang_cl(cc):
         out_base = os.path.splitext(out)[0]
-        cc_cmd = [cc, src, "/nologo", "/O2", "/LD", "/wd4819"]
-        # clang-cl doesn't support /std:c11, use -std=c11 instead
-        if is_clang_cl(cc):
-            cc_cmd += ["-std=c11"]
-        else:
-            cc_cmd += ["/std:c11"]
+        cc_cmd = [cc, src, "/nologo", "/O2", "/LD", "/wd4819", "/std:c11"]
         cc_cmd += [f"/I{dir}" for dir in include_dirs if dir is not None]
         cc_cmd += [f"/Fo{out_base + '.obj'}"]
         cc_cmd += ["/link"]

--- a/third_party/amd/backend/compiler.py
+++ b/third_party/amd/backend/compiler.py
@@ -6,7 +6,6 @@ from typing import Any, Dict, Tuple
 from types import ModuleType
 import hashlib
 import os
-import platform
 import tempfile
 import re
 import functools
@@ -14,8 +13,14 @@ import warnings
 from pathlib import Path
 
 
-def _is_windows():
-    return platform.system() == 'Windows'
+# The file may be accessed in parallel
+def try_remove(path):
+    if os.path.exists(path):
+        try:
+            os.remove(path)
+        except OSError:
+            import traceback
+            traceback.print_exc()
 
 
 def get_min_dot_size(target: GPUTarget):
@@ -443,35 +448,21 @@ class HIPBackend(BaseBackend):
         if knobs.compilation.enable_asan:
             target_features = '+xnack'
         hsaco = amd.assemble_amdgcn(src, options.arch, target_features)
-        # On Windows, NamedTemporaryFile cannot be reopened while open, so we
-        # use delete=False and manually clean up.
-        if _is_windows():
-            tmp_in = tempfile.NamedTemporaryFile(delete=False, suffix='.o')
-            tmp_out = tempfile.NamedTemporaryFile(delete=False, suffix='.hsaco')
-            try:
-                tmp_in.write(hsaco)
-                tmp_in.close()
-                tmp_out.close()
-                amd.link_hsaco(tmp_in.name, tmp_out.name)
-                with open(tmp_out.name, "rb") as fd_out:
-                    ret = fd_out.read()
-            finally:
-                try:
-                    os.unlink(tmp_in.name)
-                except OSError:
-                    pass
-                try:
-                    os.unlink(tmp_out.name)
-                except OSError:
-                    pass
-        else:
-            with tempfile.NamedTemporaryFile() as tmp_out:
-                with tempfile.NamedTemporaryFile() as tmp_in:
-                    with open(tmp_in.name, "wb") as fd_in:
-                        fd_in.write(hsaco)
-                    amd.link_hsaco(tmp_in.name, tmp_out.name)
-                with open(tmp_out.name, "rb") as fd_out:
-                    ret = fd_out.read()
+        # Use delete=False so the file can be reopened on Windows after closing.
+        # Clean up with try_remove outside the context managers.
+        with tempfile.NamedTemporaryFile(delete=False, mode='wb', suffix='.o') as tmp_in, \
+             tempfile.NamedTemporaryFile(delete=False, mode='rb', suffix='.hsaco') as tmp_out:
+            tmp_in.write(hsaco)
+            tmp_in.flush()
+            tmp_out_name = tmp_out.name
+            tmp_in_name = tmp_in.name
+
+        amd.link_hsaco(tmp_in_name, tmp_out_name)
+        with open(tmp_out_name, 'rb') as f:
+            ret = f.read()
+
+        try_remove(tmp_in_name)
+        try_remove(tmp_out_name)
         return ret
 
     def add_stages(self, stages, options, language):


### PR DESCRIPTION
@woct0rdho  this would be worth cherry-picking too. It fixes some runtime warnings while handling temp files better.